### PR TITLE
fix: translation handling to support array input in fill method

### DIFF
--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -118,20 +118,20 @@ trait HasTranslations
         return $this;
     }
 
-    public function newInstance($attributes = [], $exists = false): static
+    public function fill(array $attributes): static
     {
         $basic = Arr::except($attributes, $this->translatable());
         $translatable = Arr::only($attributes, $this->translatable());
 
-        $model = parent::newInstance($basic, $exists);
+        parent::fill($basic);
 
         foreach ($translatable as $key => $value) {
             is_iterable($value)
-                ? $model->setTranslations($key, $value)
-                : $model->setTranslation($key, $value);
+                ? $this->setTranslations($key, $value)
+                : $this->setTranslation($key, $value);
         }
 
-        return $model;
+        return $this;
     }
 
     public function translatable(): array

--- a/tests/Unit/Models/SetWithSavingTest.php
+++ b/tests/Unit/Models/SetWithSavingTest.php
@@ -14,7 +14,7 @@ test('main locale', function () {
 
     $model = fakeModel(main: $oldText);
 
-    expect($model->title)->toBeString()->toBe($oldText);
+    expect($model->{FakeValue::ColumnTitle})->toBeString()->toBe($oldText);
     expect($model->getTranslation(FakeValue::ColumnTitle))->toBe($oldText);
     expect($model->getTranslation(FakeValue::ColumnTitle, FakeValue::LocaleMain))->toBe($oldText);
 
@@ -22,7 +22,7 @@ test('main locale', function () {
     $model->setTranslation(FakeValue::ColumnTitle, $newText);
     $model->save();
 
-    expect($model->title)->toBeString()->toBe($newText);
+    expect($model->{FakeValue::ColumnTitle})->toBeString()->toBe($newText);
     expect($model->getTranslation(FakeValue::ColumnTitle))->toBe($newText);
     expect($model->getTranslation(FakeValue::ColumnTitle, FakeValue::LocaleMain))->toBe($newText);
 
@@ -48,7 +48,7 @@ test('fallback locale', function () {
 
     $model = fakeModel(fallback: $oldText);
 
-    expect($model->title)->toBeString()->toBe($oldText);
+    expect($model->{FakeValue::ColumnTitle})->toBeString()->toBe($oldText);
     expect($model->getTranslation(FakeValue::ColumnTitle))->toBe($oldText);
     expect($model->getTranslation(FakeValue::ColumnTitle, FakeValue::LocaleFallback))->toBe($oldText);
 
@@ -56,7 +56,7 @@ test('fallback locale', function () {
     $model->setTranslation(FakeValue::ColumnTitle, $newText, FakeValue::LocaleFallback);
     $model->save();
 
-    expect($model->title)->toBeString()->toBe($newText);
+    expect($model->{FakeValue::ColumnTitle})->toBeString()->toBe($newText);
     expect($model->getTranslation(FakeValue::ColumnTitle))->toBe($newText);
     expect($model->getTranslation(FakeValue::ColumnTitle, FakeValue::LocaleFallback))->toBe($newText);
 
@@ -82,7 +82,7 @@ test('custom locale', function () {
 
     $model = fakeModel(custom: $oldText);
 
-    expect($model->title)->toBeNull();
+    expect($model->{FakeValue::ColumnTitle})->toBeNull();
     expect($model->getTranslation(FakeValue::ColumnTitle))->toBeNull();
     expect($model->getTranslation(FakeValue::ColumnTitle, FakeValue::LocaleCustom))->toBe($oldText);
 
@@ -90,7 +90,7 @@ test('custom locale', function () {
     $model->setTranslation(FakeValue::ColumnTitle, $newText, FakeValue::LocaleCustom);
     $model->save();
 
-    expect($model->title)->toBeNull();
+    expect($model->{FakeValue::ColumnTitle})->toBeNull();
     expect($model->getTranslation(FakeValue::ColumnTitle))->toBeNull();
     expect($model->getTranslation(FakeValue::ColumnTitle, FakeValue::LocaleCustom))->toBe($newText);
 
@@ -125,3 +125,32 @@ test('mixed symbols', function (mixed $source, mixed $saved) {
         FakeValue::ColumnTitle => $saved,
     ]);
 })->with('mixed-values');
+
+test('array', function () {
+    $oldText = fake()->paragraph;
+    $newText = fake()->paragraph;
+
+    $model = fakeModel(main: $oldText);
+
+    expect($model->{FakeValue::ColumnTitle})->toBeString()->toBe($oldText);
+    expect($model->getTranslation(FakeValue::ColumnTitle))->toBe($oldText);
+    expect($model->getTranslation(FakeValue::ColumnTitle, FakeValue::LocaleMain))->toBe($oldText);
+
+    // That one
+    $model->update([
+        FakeValue::ColumnTitle => [
+            FakeValue::LocaleMain => $newText,
+        ],
+    ]);
+
+    expect($model->{FakeValue::ColumnTitle})->toBeString()->toBe($newText);
+    expect($model->getTranslation(FakeValue::ColumnTitle))->toBe($newText);
+    expect($model->getTranslation(FakeValue::ColumnTitle, FakeValue::LocaleMain))->toBe($newText);
+
+    assertDatabaseHas(TestModelTranslation::class, [
+        'item_id' => $model->id,
+        'locale'  => FakeValue::LocaleMain,
+
+        FakeValue::ColumnTitle => $newText,
+    ]);
+});


### PR DESCRIPTION
Update models having translations by passing iterable objects did not work

I replaced `newInstance` method by `fill` method, and it works now