### PR TITLE
Add translation scopes for Eloquent models

### DIFF
--- a/src/Concerns/HasNames.php
+++ b/src/Concerns/HasNames.php
@@ -12,4 +12,9 @@ trait HasNames
     {
         return static::class . Config::shared()->models->suffix;
     }
+
+    public function getTranslationTable(): string
+    {
+        return (new ($this->translationModelName())())->getTable();
+    }
 }

--- a/src/Concerns/Scopes.php
+++ b/src/Concerns/Scopes.php
@@ -6,6 +6,9 @@ namespace LaravelLang\Models\Concerns;
 
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @mixin \LaravelLang\Models\Concerns\HasNames
+ */
 trait Scopes
 {
     public function scopeTranslated(Builder $query): void
@@ -26,10 +29,10 @@ trait Scopes
     public function scopeWhereTranslation(Builder $query, string $translationField, $value, ?string $locale = null, string $method = 'whereHas', string $operator = '='): void
     {
         $query->$method('translations', function (Builder $query) use ($translationField, $value, $locale, $operator) {
-            $query->where($this->getTranslationsTable().'.'.$translationField, $operator, $value);
+            $query->where($this->getTranslationTable().'.'.$translationField, $operator, $value);
 
             if ($locale) {
-                $query->where($this->getTranslationsTable().'.locale', $operator, $locale);
+                $query->where($this->getTranslationTable().'.locale', $operator, $locale);
             }
         });
     }
@@ -37,10 +40,5 @@ trait Scopes
     public function scopeWhereTranslationLike(Builder $query, string $translationField, $value, ?string $locale = null): void
     {
         $this->scopeWhereTranslation($query, $translationField, $value, $locale, 'whereHas', 'LIKE');
-    }
-
-    protected function getTranslationsTable(): string
-    {
-        return (new ($this->translationModelName())())->getTable();
     }
 }

--- a/src/Concerns/Scopes.php
+++ b/src/Concerns/Scopes.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelLang\Models\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait Scopes
+{
+    public function scopeTranslated(Builder $query): void
+    {
+        $query->has('translations');
+    }
+
+    public function scopeOrWhereTranslation(Builder $query, string $translationField, $value, ?string $locale = null): void
+    {
+        $this->scopeWhereTranslation($query, $translationField, $value, $locale, 'orWhereHas');
+    }
+
+    public function scopeOrWhereTranslationLike(Builder $query, string $translationField, $value, ?string $locale = null): void
+    {
+        $this->scopeWhereTranslation($query, $translationField, $value, $locale, 'orWhereHas', 'LIKE');
+    }
+
+    public function scopeWhereTranslation(Builder $query, string $translationField, $value, ?string $locale = null, string $method = 'whereHas', string $operator = '='): void
+    {
+        $query->$method('translations', function (Builder $query) use ($translationField, $value, $locale, $operator) {
+            $query->where($this->getTranslationsTable().'.'.$translationField, $operator, $value);
+
+            if ($locale) {
+                $query->where($this->getTranslationsTable().'.locale', $operator, $locale);
+            }
+        });
+    }
+
+    public function scopeWhereTranslationLike(Builder $query, string $translationField, $value, ?string $locale = null): void
+    {
+        $this->scopeWhereTranslation($query, $translationField, $value, $locale, 'whereHas', 'LIKE');
+    }
+
+    protected function getTranslationsTable(): string
+    {
+        return (new ($this->translationModelName())())->getTable();
+    }
+}

--- a/src/HasTranslations.php
+++ b/src/HasTranslations.php
@@ -10,8 +10,6 @@ use Illuminate\Support\Arr;
 use LaravelLang\LocaleList\Locale;
 use LaravelLang\Locales\Data\LocaleData;
 use LaravelLang\Locales\Facades\Locales;
-use LaravelLang\Models\Concerns\HasNames;
-use LaravelLang\Models\Concerns\ModelLoader;
 use LaravelLang\Models\Eloquent\Scopes\FilterTranslationsScope;
 use LaravelLang\Models\Eloquent\Translation;
 use LaravelLang\Models\Services\Attribute;
@@ -28,8 +26,9 @@ use function is_iterable;
  */
 trait HasTranslations
 {
-    use ModelLoader;
-    use HasNames;
+    use Concerns\ModelLoader;
+    use Concerns\HasNames;
+    use Concerns\Scopes;
 
     public function translations(): HasMany
     {


### PR DESCRIPTION
This pull request introduces a new `Scopes` trait to support advanced query scopes for translated fields in Eloquent models, and integrates it into the translation system. Comprehensive tests are also added to verify the new querying capabilities. The main focus is to make it easier to filter models based on their translations, including support for "like" and "or" conditions.

### New Query Scopes for Translations

* Added the new `Concerns\Scopes` trait, which defines several query scopes for filtering models based on their translations, including `translated`, `whereTranslation`, `whereTranslationLike`, and their "or" variants. These scopes allow for expressive and flexible querying of translated fields.

* Integrated the new `Scopes` trait into the `HasTranslations` trait, making the new query scopes available to all models using `HasTranslations`.

### Testing and Verification

* Added extensive unit tests in `tests/Unit/Models/GetTest.php` to verify the behavior of the new translation query scopes, including tests for basic filtering, "like" queries, "or" conditions, and locale-specific queries.

### Minor Improvements

* Updated import statements in test files to ensure the correct model is used for testing the new scopes.

* Cleaned up trait imports in `HasTranslations.php` to use the new namespace structure for consistency.