### PR TITLE
Add orderByTranslation scope for sorting by translation fields

### DIFF
--- a/src/Concerns/Scopes.php
+++ b/src/Concerns/Scopes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaravelLang\Models\Concerns;
 
 use Illuminate\Database\Eloquent\Builder;
+use LaravelLang\Locales\Facades\Locales;
 
 /**
  * @mixin \LaravelLang\Models\Concerns\HasNames
@@ -41,4 +42,22 @@ trait Scopes
     {
         $this->scopeWhereTranslation($query, $translationField, $value, $locale, 'whereHas', 'LIKE');
     }
+
+    public function scopeOrderByTranslation(Builder $query, string $translationField, string $sortMethod = 'asc', ?string $locale = null): void
+    {
+        $table = $this->getTable();
+        $translationTable = $this->getTranslationTable();
+        $locale ??= Locales::getCurrent()->code;
+
+        $query
+            ->orderBy(
+                (new ($this->translationModelName())())
+                    ->query()
+                    ->select($translationField)
+                    ->where($translationTable . '.locale', $locale)
+                    ->whereColumn($translationTable . '.item_id', $table . '.id'),
+                $sortMethod
+            );
+    }
+
 }


### PR DESCRIPTION
This pull request introduces a new query scope for ordering Eloquent models by their translation values, and adds comprehensive tests to verify its behavior across various scenarios. The main focus is on enhancing multilingual sorting capabilities within the model layer.

### Translation ordering feature

* Added a new `scopeOrderByTranslation` method to the `Scopes` concern, allowing queries to be sorted by a translation field in either ascending or descending order, with support for specifying the locale or defaulting to the current locale.
* Imported the `Locales` facade to support dynamic locale resolution in the new scope.

### Unit tests for translation ordering

* Added tests to confirm that `orderByTranslation` correctly sorts model results by the translation field in ascending and descending order, for both the default and specified locales.
* Added tests to verify that ordering works as expected even when some models lack translations for the current locale, ensuring nulls are handled properly in the sort order.